### PR TITLE
Consul source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here you will find some extra Config sources, Config converters and some utils f
 * [Xml Config source](https://github.com/microprofile-extensions/config-ext/blob/master/configsource-xml/README.md)
 * [Etcd Config source](https://github.com/microprofile-extensions/config-ext/blob/master/configsource-etcd/README.md)
 * [DB Config source](https://github.com/microprofile-extensions/config-ext/blob/master/configsource-db/README.md)
+* [Consul Config source](https://github.com/microprofile-extensions/config-ext/blob/master/configsource-consul/README.md)
 
 ### Config utils
 * [Config events](https://github.com/microprofile-extensions/config-ext/blob/master/config-events/README.md)

--- a/configsource-consul/README.md
+++ b/configsource-consul/README.md
@@ -5,7 +5,8 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.microprofile-ext.config-ext/configsource-consul/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.microprofile-ext.config-ext/configsource-consul)
 [![Javadocs](https://www.javadoc.io/badge/org.microprofile-ext.config-ext/configsource-consul.svg)](https://www.javadoc.io/doc/org.microprofile-ext.config-ext/configsource-consul)
 
-Use [consul](https://consul.io/) to get config values. You can define the server details of the consul server using MicroProfile Config:
+Use [consul](https://consul.io/) to get config values. You can define the server details of the consul server using MicroProfile Config.
+Values are cached to reduce calls to consul. This config source does not support config events (yet).
 
 ## Usage
 
@@ -22,7 +23,7 @@ Use [consul](https://consul.io/) to get config values. You can define the server
 
 ## Configure options
 
-    configsource.consul.host=localhost (default)
+    configsource.consul.host (defaults to localhost)
     configsource.consul.prefix (default no prefix)
     configsource.consul.validity (default 30s)
   
@@ -30,3 +31,7 @@ Use [consul](https://consul.io/) to get config values. You can define the server
 You can disable the config source by setting this config:
     
     ConsulConfigSource.enabled=false  
+
+## Links
+* https://github.com/rikcarve/consulkv-maven-plugin
+* https://microprofile.io/project/eclipse/microprofile-config

--- a/configsource-consul/README.md
+++ b/configsource-consul/README.md
@@ -1,0 +1,32 @@
+[Back to config-ext](https://github.com/microprofile-extensions/config-ext/blob/master/README.md)
+
+# Consul Config Source
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.microprofile-ext.config-ext/configsource-consul/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.microprofile-ext.config-ext/configsource-consul)
+[![Javadocs](https://www.javadoc.io/badge/org.microprofile-ext.config-ext/configsource-consul.svg)](https://www.javadoc.io/doc/org.microprofile-ext.config-ext/configsource-consul)
+
+Use [consul](https://consul.io/) to get config values. You can define the server details of the consul server using MicroProfile Config:
+
+## Usage
+
+```xml
+
+    <dependency>
+        <groupId>org.microprofile-ext.config-ext</groupId>
+        <artifactId>configsource-consul</artifactId>
+        <version>XXXXXX</version>
+        <scope>runtime</scope>
+    </dependency>
+
+```
+
+## Configure options
+
+    configsource.consul.host=localhost (default)
+    configsource.consul.prefix (default no prefix)
+    configsource.consul.validity (default 30s)
+  
+
+You can disable the config source by setting this config:
+    
+    ConsulConfigSource.enabled=false  

--- a/configsource-consul/pom.xml
+++ b/configsource-consul/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.microprofile-ext</groupId>
+        <artifactId>config-ext</artifactId>
+        <version>1.0.6-SNAPSHOT</version>
+    </parent>
+    
+    <groupId>org.microprofile-ext.config-ext</groupId>
+    <artifactId>configsource-consul</artifactId>
+    
+    <name>Microprofile Config Extensions :: Consul config source</name>
+    <description>A config that gets the values from an Consul server</description>
+
+    <properties>
+        <junit.jupiter.version>5.3.2</junit.jupiter.version>
+        <junit.platform.version>1.3.2</junit.platform.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>com.ecwid.consul</groupId>
+            <artifactId>consul-api</artifactId>
+            <version>1.4.2</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>configsource-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.6</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+            <version>${junit.platform.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
+        </dependency>
+
+	</dependencies>
+</project>

--- a/configsource-consul/src/main/java/org/microprofileext/config/source/consul/ConsulConfigSource.java
+++ b/configsource-consul/src/main/java/org/microprofileext/config/source/consul/ConsulConfigSource.java
@@ -1,0 +1,136 @@
+package org.microprofileext.config.source.consul;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import org.apache.commons.text.StringSubstitutor;
+import org.microprofileext.config.source.base.EnabledConfigSource;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.kv.model.GetValue;
+
+import lombok.extern.java.Log;
+
+/**
+ * Consul config source
+ * @author Arik Dasen
+ * 
+ */
+@Log
+public class ConsulConfigSource extends EnabledConfigSource {
+    
+    private static final String NAME = "ConsulConfigSource";
+
+    private static final String KEY_PREFIX = "configsource.consul.";    
+    private static final String KEY_HOST = KEY_PREFIX + "host";
+    private static final String DEFAULT_HOST = "localhost";
+    private static final String KEY_VALIDITY = KEY_PREFIX + "validity";
+    private static final Long DEFAULT_VALIDITY = 30L;
+    private static final String KEY_CONSUL_PREFIX = KEY_PREFIX + "prefix";
+
+    // enable variable substitution for configsource config
+    private StringSubstitutor substitutor = new StringSubstitutor(s -> getConfig().getOptionalValue(s, String.class).orElse(""));
+
+    private ConsulClient client = null;
+    private Long validity = null;
+    private String prefix = null;
+    
+    private Map<String, TimedEntry> cache = new ConcurrentHashMap<>();
+    
+    public ConsulConfigSource(){
+        super.initOrdinal(320);
+    }
+    
+    @Override
+    public Map<String, String> getPropertiesIfEnabled() {
+        return cache.entrySet()
+                .stream()
+                .filter(e -> e.getValue().getValue() != null)
+                .collect(Collectors.toMap(
+                        e -> e.getKey(),
+                        e -> e.getValue().getValue()));
+    }
+
+    @Override
+    public String getValue(String key) {
+        if (key.startsWith(KEY_PREFIX)) {
+            // in case we are about to configure ourselves we simply ignore that key
+            return null;
+        }
+        
+        TimedEntry entry = cache.get(key);
+        if (entry == null || entry.isExpired()) {
+            log.log(Level.FINE, "load {0} from consul", key);
+            GetValue value = null;
+            try {
+                value = getClient().getKVValue(getPrefix() + key).getValue();
+            } catch (Exception e) {
+                log.log(Level.FINE, "consul getKVValue failed: {0}", e.getMessage());
+//                if (consulError == null || consulError.isExpired()) {
+//                    log.warn("consul getKVValue failed, {}" , e.getMessage());
+//                    consulError = new TimedEntry("");
+//                }
+                if (entry != null) {
+                    return entry.getValue();
+                }
+            }
+            if (value == null) {
+                cache.put(key, new TimedEntry(null));
+                return null;
+            }
+            String decodedValue = value.getDecodedValue();
+            cache.put(key, new TimedEntry(decodedValue));
+            return decodedValue;
+        }
+        return entry.getValue();
+        
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    private Long getValidity() {
+        if (validity == null) {
+            validity = getConfig().getOptionalValue(KEY_VALIDITY, Long.class).orElse(DEFAULT_VALIDITY) * 1000L;
+        }
+        return validity;
+    }
+
+    private String getPrefix() {
+        if (prefix == null) {
+            prefix = getConfig().getOptionalValue(KEY_CONSUL_PREFIX, String.class).orElse("");
+        }
+        return prefix;
+    }
+
+    private ConsulClient getClient(){
+        if(this.client == null ){
+            log.info("Loading [consul] MicroProfile ConfigSource");
+            client = new ConsulClient(substitutor.replace(getConfig().getOptionalValue(KEY_HOST, String.class).orElse(DEFAULT_HOST)));
+        }
+        return this.client;
+    }
+
+    class TimedEntry {
+        private final String value;
+        private final long timestamp;
+
+        public TimedEntry(String value) {
+            this.value = value;
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public boolean isExpired() {
+            return (timestamp + getValidity()) < System.currentTimeMillis();
+        }
+    }
+
+}

--- a/configsource-consul/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/configsource-consul/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+org.microprofileext.config.source.consul.ConsulConfigSource

--- a/configsource-consul/src/test/java/org/microprofileext/config/source/consul/ConsulConfigSourceTest.java
+++ b/configsource-consul/src/test/java/org/microprofileext/config/source/consul/ConsulConfigSourceTest.java
@@ -1,0 +1,87 @@
+package org.microprofileext.config.source.consul;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.kv.model.GetValue;
+
+class ConsulConfigSourceTest {
+
+    private ConsulConfigSource configSource;
+
+    @BeforeEach
+    public void init() {
+        configSource = new ConsulConfigSource(mock(ConsulClient.class));
+    }
+    
+    @Test
+    void testGetProperties_empty() {
+        assertTrue(configSource.getProperties().isEmpty());
+    }
+
+    @Test
+    void testGetProperties_one() {
+        GetValue value = new GetValue();
+        value.setValue(Base64.getEncoder().encodeToString("hello".getBytes()));
+        when(configSource.client.getKVValue(anyString())).thenReturn(new Response<GetValue>(value, 0L, true, 0L));
+        configSource.getValue("test");
+        assertEquals(1, configSource.getProperties().size());
+    }
+
+    @Test
+    void testGetValue_null() {
+        when(configSource.client.getKVValue(anyString())).thenReturn(new Response<GetValue>(null, 0L, true, 0L));
+        assertNull(configSource.getValue("test"));
+    }
+
+    @Test
+    void testGetValue() {
+        GetValue value = new GetValue();
+        value.setValue(Base64.getEncoder().encodeToString("hello".getBytes()));
+        when(configSource.client.getKVValue(anyString())).thenReturn(new Response<GetValue>(value, 0L, true, 0L));
+        assertEquals("hello", configSource.getValue("test"));
+    }
+
+    @Test
+    void testGetValue_cache() {
+        GetValue value = new GetValue();
+        value.setValue(Base64.getEncoder().encodeToString("hello".getBytes()));
+        when(configSource.client.getKVValue(anyString())).thenReturn(new Response<GetValue>(value, 0L, true, 0L));
+        configSource.getValue("test");
+        configSource.getValue("test");
+        verify(configSource.client, times(1)).getKVValue("test");
+    }
+
+    @Test
+    void testGetValue_exception() {
+        when(configSource.client.getKVValue(anyString())).thenThrow(RuntimeException.class);
+        assertNull(configSource.getValue("test"));
+    }
+
+    @Test
+    void testGetValue_prefix() {
+        System.setProperty("configsource.consul.prefix", "myprefix");
+        // reinitialize after system property set (systemproperty have been cached in default configsource)
+        configSource = new ConsulConfigSource(mock(ConsulClient.class));
+        GetValue value = new GetValue();
+        value.setValue(Base64.getEncoder().encodeToString("hello".getBytes()));
+        when(configSource.client.getKVValue(anyString())).thenReturn(new Response<GetValue>(value, 0L, true, 0L));
+        configSource.getValue("test");
+        System.clearProperty("configsource.consul.prefix");
+        verify(configSource.client, times(1)).getKVValue("myprefix/test");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
         <module>configsource-xml</module>
         <module>configsource-etcd</module>
         <module>configsource-db</module>
+        <module>configsource-consul</module>
         <!-- converters -->
         <module>configconverter-list</module>
         <module>configconverter-json</module>


### PR DESCRIPTION
Migrated consul config source from https://github.com/rikcarve/mp-config-consul.
Also caches values, although it might not be as important as in the database config source. Null values are also cached as a configsource is often called for values it does not provide.
I did not add CDI events as I think this only makes sense when the configsource actively polls for new/changed values (could be added once we *listen* to config changes in consul). But I might not have understood the principle correctly ;-)
Authentication is missing as I never used that in Consul so far. Definitly something I will add in the future.
Ah, and I guess I do not have write permission to the repo, right?