### PR TITLE
#18: Fix AbstractUrlBasedSource leading to deployment errors on Payara on Windows

### DIFF
--- a/configsource-filebase/src/main/java/org/microprofileext/config/source/base/file/AbstractUrlBasedSource.java
+++ b/configsource-filebase/src/main/java/org/microprofileext/config/source/base/file/AbstractUrlBasedSource.java
@@ -26,6 +26,7 @@ public abstract class AbstractUrlBasedSource extends EnabledConfigSource impleme
     private final LinkedHashMap<URL,Map<String, String>> propertiesMap = new LinkedHashMap<>();
     private final Map<String, String> properties = new HashMap<>();
     private String urlInputString;
+    private String escapedUrlInputString;
     private String keySeparator;
     private boolean pollForChanges;
     private int pollInterval;
@@ -46,6 +47,7 @@ public abstract class AbstractUrlBasedSource extends EnabledConfigSource impleme
         this.pollForChanges = loadPollForChanges();
         this.pollInterval = loadPollInterval();
         this.urlInputString = loadUrlPath();
+        this.escapedUrlInputString = escapeUrlInputString(this.urlInputString);
         this.loadUrls(urlInputString);
         
         super.initOrdinal(500); 
@@ -68,7 +70,7 @@ public abstract class AbstractUrlBasedSource extends EnabledConfigSource impleme
 
     @Override
     public String getName() {
-        return getClassKeyPrefix() + UNDERSCORE + this.urlInputString;
+        return getClassKeyPrefix() + UNDERSCORE + this.escapedUrlInputString;
     }
     
     @Override
@@ -78,6 +80,10 @@ public abstract class AbstractUrlBasedSource extends EnabledConfigSource impleme
         mergeProperties();
         Map<String, String> after = new HashMap<>(this.properties);
         if(notifyOnChanges)ChangeEventNotifier.getInstance().detectChangesAndFire(before, after,getName());
+    }
+    
+    private String escapeUrlInputString(String urlInputString) {
+        return urlInputString != null ? urlInputString.replaceAll("[:=]", "_") : "";
     }
     
     private void initialLoad(URL url){


### PR DESCRIPTION
Hi @phillip-kruger, 

as described in microprofile-extensions/config-ext#18, there is a problem that any ConfigSource that extends the `AbstractUrlBasedSource` is not deployable on Payara on Windows. The specifics of why this fails are also described in the linked smallrye/smallrye-config#127 - however, even though both issues are rather old and have already been closed, the problem is still relevant and reproducible on Windows.

This PR fixes the issue by escaping the urlInputString used for generating the ConfigSource name so that it does not contain any characters which are illegal in a Java property key. I opted for creating a separate member variable `escapedUrlInputString` in `AbstractUrlBasedSource` so that we do not need to perform the replacement over and over again.