### PR TITLE
#25: make it microprofile 4.0 compatible

### DIFF
--- a/configsource-base/src/main/java/org/microprofileext/config/source/base/BaseConfigSource.java
+++ b/configsource-base/src/main/java/org/microprofileext/config/source/base/BaseConfigSource.java
@@ -19,6 +19,7 @@
  */
 package org.microprofileext.config.source.base;
 
+import java.util.Set;
 import java.util.logging.Level;
 import lombok.Getter;
 import lombok.extern.java.Log;
@@ -47,7 +48,7 @@ public abstract class BaseConfigSource implements ConfigSource {
     }
     
     @Override
-    Set<String> getPropertyNames() {
+    public Set<String> getPropertyNames() {
         return getProperties().keySet();
     }
     

--- a/configsource-base/src/main/java/org/microprofileext/config/source/base/BaseConfigSource.java
+++ b/configsource-base/src/main/java/org/microprofileext/config/source/base/BaseConfigSource.java
@@ -47,6 +47,11 @@ public abstract class BaseConfigSource implements ConfigSource {
     }
     
     @Override
+    Set<String> getPropertyNames() {
+        return getProperties().keySet();
+    }
+    
+    @Override
     public int getOrdinal() {
         return ordinal;
     }


### PR DESCRIPTION
just add the default implementation of getPropertyNames() to BaseConfigSource