### PR TITLE
Update consul and db config source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# IntelliJ
+.idea/
+*.iml
+
 # eclipse
 .classpath
 .project

--- a/configsource-base/src/main/java/org/microprofileext/config/source/base/ExpiringMap.java
+++ b/configsource-base/src/main/java/org/microprofileext/config/source/base/ExpiringMap.java
@@ -1,0 +1,82 @@
+package org.microprofileext.config.source.base;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * A simple map with an expiring policy. Note: this map can also store null
+ * values!
+ *
+ * @param <K> key
+ * @param <V> value
+ */
+public class ExpiringMap<K, V> {
+    long validity;
+    private Map<K, TimedEntry<V>> cache = new ConcurrentHashMap<>();
+
+    public ExpiringMap(long validity) {
+        this.validity = validity;
+    }
+
+    /**
+     * Similar to Map::computeIfAbsent, but the mapping function can throw an
+     * exception, which can be handled with a consumer.
+     * 
+     * @param key         key
+     * @param action      mapping function
+     * @param onException exception handler
+     * @return
+     */
+    public V getOrCompute(K key, CheckedFunction<K, V> action, Consumer<K> onException) {
+        TimedEntry<V> entry = cache.get(key);
+        if (entry == null || entry.isExpired()) {
+            try {
+                V value = action.apply(key);
+                put(key, value);
+                return value;
+            } catch (Exception e) {
+                onException.accept(key);
+            }
+        }
+        // if the entry was never cached, then it will be null
+        return entry != null ? entry.get() : null;
+    }
+
+    public void put(K key, V value) {
+        cache.put(key, new TimedEntry<V>(value));
+    }
+
+    /**
+     * Access underlying map, use with care
+     * 
+     * @return
+     */
+    public Map<K, TimedEntry<V>> getMap() {
+        return cache;
+    }
+
+    @FunctionalInterface
+    public interface CheckedFunction<T, R> {
+        R apply(T t) throws Exception;
+    }
+
+    public class TimedEntry<E> {
+        private final E value;
+        private final long timestamp;
+
+        public TimedEntry(E value) {
+            this.value = value;
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        public E get() {
+            return value;
+        }
+
+        public boolean isExpired() {
+            return (timestamp + validity) < System.currentTimeMillis();
+        }
+    }
+
+}

--- a/configsource-consul/pom.xml
+++ b/configsource-consul/pom.xml
@@ -14,15 +14,14 @@
     <description>A config that gets the values from an Consul server</description>
 
     <properties>
-        <junit.jupiter.version>5.3.2</junit.jupiter.version>
-        <junit.platform.version>1.3.2</junit.platform.version>
+        <junit.jupiter.version>5.7.0</junit.jupiter.version>
     </properties>
     
     <dependencies>
         <dependency>
             <groupId>com.ecwid.consul</groupId>
             <artifactId>consul-api</artifactId>
-            <version>1.4.2</version>
+            <version>1.4.5</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -31,27 +30,15 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>1.6</version>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <version>${junit.platform.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
+            <version>3.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/configsource-consul/pom.xml
+++ b/configsource-consul/pom.xml
@@ -54,6 +54,12 @@
             <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-junit-jupiter</artifactId>
+            <version>5.11.2</version>
+            <scope>test</scope>
+        </dependency>
 
 	</dependencies>
 </project>

--- a/configsource-consul/src/main/java/org/microprofileext/config/source/consul/Configuration.java
+++ b/configsource-consul/src/main/java/org/microprofileext/config/source/consul/Configuration.java
@@ -1,0 +1,57 @@
+package org.microprofileext.config.source.consul;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+public class Configuration {
+
+    private Config config = ConfigProviderResolver.instance()
+            .getBuilder()
+            .addDefaultSources()
+            .build();
+
+    private String consulHost = getConfigValue("configsource.consul.host", "");
+    private String consulHostList = getConfigValue("configsource.consul.hosts", "");
+    private int consulPort = Integer.valueOf(getConfigValue("configsource.consul.port", "8500"));
+    private long validity = Long.valueOf(getConfigValue("configsource.consul.validity", "30")) * 1000L;
+    private String prefix = addSlash(getConfigValue("configsource.consul.prefix", ""));
+    private String token = getConfigValue("configsource.consul.token", null);
+    private boolean listAll = Boolean.valueOf(getConfigValue("configsource.consul.list-all", "false"));
+
+    public long getValidity() {
+        return validity;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getConsulHost() {
+        return consulHost;
+    }
+
+    public String getConsulHostList() {
+        return consulHostList;
+    }
+
+    public int getConsulPort() {
+        return consulPort;
+    }
+
+    public boolean listAll() {
+        return listAll;
+    }
+
+    private String getConfigValue(String key, String defaultValue) {
+        return config.getOptionalValue(key, String.class).orElse(defaultValue);
+    }
+
+    private String addSlash(String envOrSystemProperty) {
+        return envOrSystemProperty.isEmpty() ? "" : envOrSystemProperty + "/";
+    }
+
+}

--- a/configsource-consul/src/main/java/org/microprofileext/config/source/consul/ConsulClientWrapper.java
+++ b/configsource-consul/src/main/java/org/microprofileext/config/source/consul/ConsulClientWrapper.java
@@ -1,0 +1,120 @@
+package org.microprofileext.config.source.consul;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.kv.model.GetValue;
+import lombok.extern.java.Log;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+@Log
+public class ConsulClientWrapper {
+
+    private String host;
+    private List<String> peers = null;
+    private int port;
+    private String token;
+    ConsulClient client = null;
+
+    public ConsulClientWrapper(String host, String hosts, int port, String token) {
+        this.host = host;
+        if (hosts != null && !hosts.isEmpty()) {
+            peers = Arrays.asList(hosts.split(","));
+        }
+        this.port = port;
+        this.token = token;
+    }
+
+    public ConsulClient getClient() {
+        initConsulClient();
+        return client;
+    }
+
+    public String getValue(String key) {
+        try {
+            String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
+            GetValue value = retry(2, () -> getClient().getKVValue(encodedKey, token).getValue(), () -> forceReconnect());
+            return value == null ? null : value.getDecodedValue();
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            forceReconnect();
+            throw e;
+        }
+    }
+
+    public List<Entry<String, String>> getKeyValuePairs(String prefix) {
+        try {
+            String encodedPrefix = URLEncoder.encode(prefix, StandardCharsets.UTF_8.name());
+            List<GetValue> values = retry(2, () -> getClient().getKVValues(encodedPrefix, token).getValue(), () -> forceReconnect());
+            return values.stream()
+                    .map(v -> new SimpleEntry<String, String>(v.getKey(), v.getDecodedValue()))
+                    .collect(Collectors.toList());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            forceReconnect();
+            throw e;
+        }
+    }
+
+    void initConsulClient() {
+        if (peers == null) {
+            client = new ConsulClient(host, port);
+            peers = client.getStatusPeers().getValue().stream()
+                    .map(s -> s.split(":")[0])
+                    .collect(Collectors.toList());
+        }
+        if (client == null) {
+            client = getClientToAnyConsulHost();
+        }
+    }
+
+    private ConsulClient getClientToAnyConsulHost() {
+        return peers.stream()
+                .map(host -> new ConsulClient(host, port))
+                .filter(this::isConsulReachable)
+                .findAny()
+                .orElseThrow(() -> new RuntimeException("No Consul host could be reached."));
+    }
+
+    private boolean isConsulReachable(ConsulClient client) {
+        try {
+            Response<String> leader = client.getStatusLeader();
+            log.log(Level.INFO, () -> "Successfully established connection to Consul. Current cluster leader is " + leader.getValue());
+        } catch (Exception e) {
+            log.log(Level.INFO, () -> "Could not establish connection to consul: " + e.getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    private <T> T retry(int maxRetries, Supplier<T> supplier, Runnable onFailedAttempt) {
+        int retries = 0;
+        RuntimeException lastException = null;
+        while (retries <= maxRetries) {
+            try {
+                return supplier.get();
+            } catch (RuntimeException e) {
+                lastException = e;
+                onFailedAttempt.run();
+                retries++;
+            }
+        }
+        throw lastException;
+    }
+
+    private void forceReconnect() {
+        client = null;
+    }
+
+}

--- a/configsource-consul/src/test/java/org/microprofileext/config/source/consul/ConfigurationTest.java
+++ b/configsource-consul/src/test/java/org/microprofileext/config/source/consul/ConfigurationTest.java
@@ -1,0 +1,86 @@
+package org.microprofileext.config.source.consul;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ConfigurationTest {
+
+    @Test
+    public void testGetValidity() throws Exception {
+        Configuration config = new Configuration();
+        assertEquals(30000, config.getValidity());
+    }
+
+    @Test
+    public void testGetValidity_fromSys() throws Exception {
+        System.setProperty("configsource.consul.validity", "10");
+        Configuration config = new Configuration();
+        assertEquals(10000, config.getValidity());
+        System.clearProperty("configsource.consul.validity");
+    }
+
+    @Test
+    public void testGetPrefix() throws Exception {
+        Configuration config = new Configuration();
+        assertEquals("", config.getPrefix());
+    }
+
+    @Test
+    public void testGetPrefix_withSlash() throws Exception {
+        System.setProperty("configsource.consul.prefix", "jax");
+        Configuration config = new Configuration();
+        assertEquals("jax/", config.getPrefix());
+        System.clearProperty("configsource.consul.prefix");
+    }
+
+    @Test
+    public void testGetPrefix_withSubstitution() throws Exception {
+        System.setProperty("configsource.consul.prefix", "applications/${appname}");
+        System.setProperty("appname", "jax");
+        Configuration config = new Configuration();
+        assertEquals("applications/jax/", config.getPrefix());
+        System.clearProperty("configsource.consul.prefix");
+        System.clearProperty("appName");
+    }
+
+    @Test
+    public void testGetConsulHost() throws Exception {
+        Configuration config = new Configuration();
+        assertEquals("", config.getConsulHost());
+    }
+
+    @Test
+    public void testGetConsulHost_fromSys() throws Exception {
+        System.setProperty("configsource.consul.host", "jax");
+        Configuration config = new Configuration();
+        assertEquals("jax", config.getConsulHost());
+        System.clearProperty("configsource.consul.host");
+    }
+
+    @Test
+    public void testGetToken() throws Exception {
+        System.setProperty("configsource.consul.token", "token");
+        Configuration config = new Configuration();
+        assertEquals("token", config.getToken());
+        System.clearProperty("configsource.consul.token");
+    }
+
+    @Test
+    public void testGetToken_not_configured() throws Exception {
+        Configuration config = new Configuration();
+        assertNull(config.getToken());
+    }
+
+    @Test
+    public void testGetConsulHost_fromSys_withSubstitution() throws Exception {
+        System.setProperty("configsource.consul.host", "${docker.host}");
+        System.setProperty("docker.host", "sub");
+        Configuration config = new Configuration();
+        assertEquals("sub", config.getConsulHost());
+        System.clearProperty("configsource.consul.host");
+        System.clearProperty("docker.host");
+    }
+
+}

--- a/configsource-consul/src/test/java/org/microprofileext/config/source/consul/ConsulClientWrapperTest.java
+++ b/configsource-consul/src/test/java/org/microprofileext/config/source/consul/ConsulClientWrapperTest.java
@@ -1,0 +1,97 @@
+package org.microprofileext.config.source.consul;
+
+import com.ecwid.consul.v1.OperationException;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.junit.jupiter.MockServerExtension;
+
+import java.util.List;
+import java.util.Map.Entry;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+@ExtendWith(MockServerExtension.class)
+public class ConsulClientWrapperTest {
+
+    ConsulClientWrapper clientWrapper;
+
+    ClientAndServer clientServer;
+
+    @BeforeEach
+    public void init(ClientAndServer client) {
+        clientServer = client;
+        clientServer.reset();
+        clientServer.when(request().withPath("/v1/status/leader")).respond(response().withBody("localhost"));
+        clientServer.when(request().withPath("/v1/status/peers")).respond(response().withBody("[\"localhost:8300\"]"));
+        clientServer.when(request().withPath("/v1/kv/test")).respond(response().withBody("[{\"LockIndex\":0,\"Key\":\"test\",\"Flags\":0,\"Value\":\"aGVsbG8=\",\"CreateIndex\":1,\"ModifyIndex\":2}]"));
+        clientServer.when(request().withPath("/v1/kv/testFromToken").withQueryStringParameter("token", "tokenValue")).respond(response().withBody("[{\"LockIndex\":0,\"Key\":\"testFromToken\",\"Flags\":0,\"Value\":\"aGVsbG8=\",\"CreateIndex\":1,\"ModifyIndex\":2}]"));
+        clientServer.when(request().withPath("/v1/kv/%25dev.property.somevalue.%22com.test.app.config%22")).respond(response().withBody("[{\"LockIndex\":0,\"Key\":\"testFromToken\",\"Flags\":0,\"Value\":\"aGVsbG8=\",\"CreateIndex\":1,\"ModifyIndex\":2}]"));
+        clientServer.when(request().withPath("/v1/kv/myapp")).respond(response().withBody("[{\"LockIndex\":0,\"Key\":\"test\",\"Flags\":0,\"Value\":\"aGVsbG8=\",\"CreateIndex\":1,\"ModifyIndex\":2}]"));
+        clientWrapper = new ConsulClientWrapper("localhost", null, clientServer.getLocalPort(), null);
+    }
+
+    @Test
+    public void testGetClient_singleHost() {
+        assertNotNull(clientWrapper.getClient());
+    }
+
+    @Test
+    public void testGetClient_peers() {
+        clientWrapper = new ConsulClientWrapper(null, "localhost", clientServer.getLocalPort(), null);
+        assertNotNull(clientWrapper.getClient());
+    }
+
+    @Test
+    public void testGetClient_hosts_1stnotAvail() {
+        clientWrapper = new ConsulClientWrapper(null, "localhost2,localhost", clientServer.getLocalPort(), null);
+        assertNotNull(clientWrapper.getClient());
+    }
+
+    @Test
+    public void testGetValue_with_token_found() {
+        clientWrapper = new ConsulClientWrapper("localhost", null, clientServer.getLocalPort(), "tokenValue");
+        String value = clientWrapper.getValue("testFromToken");
+        assertEquals("hello", value);
+    }
+
+    @Test
+    public void testGetValue_found() {
+        String value = clientWrapper.getValue("test");
+        assertEquals("hello", value);
+    }
+
+    @Test
+    public void testGetValue_keys_that_need_url_encoding() {
+        String value = clientWrapper.getValue("%dev.property.somevalue.\"com.test.app.config\"");
+        assertEquals("hello", value);
+    }
+
+    @Test
+    public void testGetValue_not_found() {
+        String value = clientWrapper.getValue("nope");
+        assertNull(value);
+    }
+
+    @Test
+    public void testGetKeyValuePairs() {
+        List<Entry<String, String>> value = clientWrapper.getKeyValuePairs("myapp");
+        assertEquals(1, value.size());
+    }
+
+    @Test
+    public void testGetValue_force_reconnect() {
+        clientServer.clear(request().withPath("/v1/kv/test"));
+        clientServer.when(request().withPath("/v1/kv/test")).respond(response().withStatusCode(HttpStatus.SC_SERVICE_UNAVAILABLE));
+        assertThrows(OperationException.class, () -> clientWrapper.getValue("test"));
+        clientServer.clear(request().withPath("/v1/kv/test"));
+        clientServer.when(request().withPath("/v1/kv/test")).respond(response().withBody("[{\"LockIndex\":0,\"Key\":\"test\",\"Flags\":0,\"Value\":\"aGVsbG8=\",\"CreateIndex\":1,\"ModifyIndex\":2}]"));
+        String value = clientWrapper.getValue("test");
+        assertEquals("hello", value);
+    }
+
+}

--- a/configsource-db/pom.xml
+++ b/configsource-db/pom.xml
@@ -13,8 +13,7 @@
     <description>A config that get the values from a datasource</description>
 
     <properties>
-        <junit.jupiter.version>5.3.2</junit.jupiter.version>
-        <junit.platform.version>1.3.2</junit.platform.version>
+        <junit.jupiter.version>5.7.0</junit.jupiter.version>
     </properties>
 
     <dependencies>
@@ -25,27 +24,15 @@
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>config-events</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <version>${junit.platform.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.4</version>
+            <version>3.6.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/configsource-db/src/main/java/org/microprofileext/config/source/db/DatasourceConfigSource.java
+++ b/configsource-db/src/main/java/org/microprofileext/config/source/db/DatasourceConfigSource.java
@@ -1,127 +1,80 @@
 package org.microprofileext.config.source.db;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-
-import org.microprofileext.config.source.base.EnabledConfigSource;
-
 import lombok.extern.java.Log;
-import org.microprofileext.config.event.ChangeEvent;
-import org.microprofileext.config.event.ChangeEventNotifier;
-import org.microprofileext.config.event.Type;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.microprofileext.config.source.base.EnabledConfigSource;
+import org.microprofileext.config.source.base.ExpiringMap;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 @Log
 public class DatasourceConfigSource extends EnabledConfigSource {
-    private static final String NAME = "DatasourceConfigSource";
-    
-    private final Map<String, TimedEntry> cache = new ConcurrentHashMap<>();
+
+    private static final String VALIDITY_KEY = "configsource.db.validity";
+    private static final String CONFIGSOURCE_ORDINAL_KEY = "configsource.db.ordinal";
+
+    private Config config;
     Repository repository = null;
-    private Long validity = null;
-    private boolean notifyOnChanges;
-    
+    ExpiringMap<String, String> cache = null;
+
     public DatasourceConfigSource() {
+        config = getConfig();
         log.info("Loading [db] MicroProfile ConfigSource");
-        this.notifyOnChanges = loadNotifyOnChanges();
-        super.initOrdinal(120);
+        super.initOrdinal(450);
     }
 
     @Override
-    public Map<String, String> getPropertiesIfEnabled() {
+    protected Map<String, String> getPropertiesIfEnabled() {
         initRepository();
-        return repository.getAllConfigValues();
+        try {
+            return repository.getAllConfigValues();
+        } catch (SQLException e) {
+            log.info("query failed: " + e.getMessage());
+            clearRepository();
+        }
+        return new HashMap<>();
     }
 
     @Override
     public String getValue(String propertyName) {
-        if (CONFIG_ORDINAL.equals(propertyName)) {
-            return null;
-        }
-        
         initRepository();
-        initValidity();
-        
-        // TODO: Cache null values ? So if the config is not in the DB, cache the empty value
-        // TODO: If not first time load, fire NEW Event ?
-        TimedEntry entry = cache.get(propertyName);
-        
-        if (entry == null){
-            // First time read (Or no config)
-            return readFromDB(propertyName);
-        }else if(entry.isExpired()) {
-            // Time to refresh
-            ChangeEventNotifier changeEventNotifier = ChangeEventNotifier.getInstance();
-            String oldValue = entry.getValue();
-            String newValue = readFromDB(propertyName);
-            if(notifyOnChanges){
-                // Remove Event
-                if(newValue==null){
-                    changeEventNotifier.fire(new ChangeEvent(Type.REMOVE,propertyName,changeEventNotifier.getOptionalOldValue(oldValue),null,NAME));
-                // Change Event
-                }else if(!oldValue.equals(newValue)){
-                    changeEventNotifier.fire(new ChangeEvent(Type.UPDATE,propertyName,changeEventNotifier.getOptionalOldValue(oldValue),newValue,NAME));
-                }
-            }
-            
-            return newValue;
-        }else{
-            // Read from cache
-            return entry.getValue();
-        }
-        
+        initCache();
+
+        return cache.getOrCompute(propertyName, p -> repository.getConfigValue(p), (e) -> clearRepository());
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "DatasourceConfigSource";
     }
 
-    private String readFromDB(String propertyName){
-        log.log(Level.FINE, () -> "load " + propertyName + " from db");
-        String value = repository.getConfigValue(propertyName);
-        cache.put(propertyName, new TimedEntry(value));
-        return value;
+    @Override
+    public int getOrdinal() {
+        return config.getOptionalValue(CONFIGSOURCE_ORDINAL_KEY, Integer.class).orElse(450);
     }
-    
-    private void initRepository(){
+
+    private void initRepository() {
         if (repository == null) {
             // late initialization is needed because of the EE datasource.
-            repository = new Repository(getConfig());
+            repository = new Repository(config);
         }
     }
-    
-    private void initValidity(){
-        if (validity == null) {
-            validity = getConfig().getOptionalValue("configsource.db.validity", Long.class).orElse(30000L);
-        }
-    }
-    
-    private String getConfigKey(String subKey){
-        return "configsource.db." + subKey;
-    }
-    
-    private boolean loadNotifyOnChanges(){
-        return getConfig().getOptionalValue(getConfigKey(NOTIFY_ON_CHANGES), Boolean.class).orElse(DEFAULT_NOTIFY_ON_CHANGES);
-    }
-    
-    class TimedEntry {
-        private final String value;
-        private final long timestamp;
 
-        public TimedEntry(String value) {
-            this.value = value;
-            this.timestamp = System.currentTimeMillis();
-        }
+    void clearRepository() {
+        repository = null;
+    }
 
-        public String getValue() {
-            return value;
-        }
-
-        public boolean isExpired() {
-            return (timestamp + validity) < System.currentTimeMillis();
+    private void initCache() {
+        if (cache == null) {
+            long validity = config.getOptionalValue(VALIDITY_KEY, Long.class).orElse(30000L);
+            cache = new ExpiringMap<>(validity);
         }
     }
-    
-    private static final String NOTIFY_ON_CHANGES = "notifyOnChanges";
-    private static final boolean DEFAULT_NOTIFY_ON_CHANGES = true;
+
 }

--- a/configsource-db/src/main/java/org/microprofileext/config/source/db/Repository.java
+++ b/configsource-db/src/main/java/org/microprofileext/config/source/db/Repository.java
@@ -44,39 +44,35 @@ public class Repository {
         }
     }
     
-    public Map<String, String> getAllConfigValues() {
+    public synchronized Map<String, String> getAllConfigValues() throws SQLException {
         Map<String, String> result = new HashMap<>();
         if (selectAll != null) {
-            try {
-                ResultSet rs = selectAll.executeQuery();
+            try (ResultSet rs = selectAll.executeQuery()) {
                 while (rs.next()) {
                     result.put(rs.getString(1), rs.getString(2));
                 }
-            } catch (SQLException e) {
-                log.log(Level.FINE, () -> "query for config values failed:}" + e.getMessage());
             }
         }
         return result;
     }
     
-    public String getConfigValue(String key) {
+    public synchronized String getConfigValue(String key) throws SQLException {
         if (selectOne != null) {
-            try {
-                selectOne.setString(1, key);
-                ResultSet rs = selectOne.executeQuery();
+            selectOne.setString(1, key);
+            try (ResultSet rs = selectOne.executeQuery()) {
                 if (rs.next()) {
                     return rs.getString(1);
                 }
-            } catch (SQLException e) {
-                log.log(Level.FINE, () -> "query for config value failed: " + e.getMessage());
             }
+        } else {
+            throw new SQLException("datasource not initialized");
         }
         return null;
     }
-    
+
     private DataSource getDatasource(String jndi) {
         try {
-            return (DataSource) InitialContext.doLookup(jndi);
+            return InitialContext.doLookup(jndi);
         } catch (NamingException e) {
             log.log(Level.WARNING, () -> "Could not get datasource: " + e.getMessage());
             return null;

--- a/configsource-db/src/test/java/org/microprofileext/config/source/db/DatasourceConfigSourceTest.java
+++ b/configsource-db/src/test/java/org/microprofileext/config/source/db/DatasourceConfigSourceTest.java
@@ -1,19 +1,16 @@
 package org.microprofileext.config.source.db;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.microprofileext.config.source.db.DatasourceConfigSource;
-import org.microprofileext.config.source.db.Repository;
+import org.microprofileext.config.source.base.ExpiringMap;
+import org.mockito.Mockito;
+
+import java.sql.SQLException;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 class DatasourceConfigSourceTest {
 
@@ -21,8 +18,9 @@ class DatasourceConfigSourceTest {
 
     @BeforeEach
     public void init() {
-        configSource = new DatasourceConfigSource();
+        configSource = Mockito.spy(new DatasourceConfigSource());
         configSource.repository = mock(Repository.class);
+        configSource.cache = new ExpiringMap<String, String>(30000);
     }
 
     @Test
@@ -36,31 +34,53 @@ class DatasourceConfigSourceTest {
     }
 
     @Test
-    public void testGetProperties_null() {
+    public void testGetProperties_null() throws Exception {
         when(configSource.repository.getConfigValue(anyString())).thenReturn(null);
         configSource.getValue("test");
         assertTrue(configSource.getProperties().isEmpty());
     }
 
     @Test
-    public void testGetProperties_one() {
+    public void testGetProperties_one() throws Exception {
         when(configSource.repository.getAllConfigValues()).thenReturn(Collections.singletonMap("test", "value"));
         configSource.getValue("test");
         assertEquals(1, configSource.getProperties().size());
     }
 
     @Test
-    public void testGetValue() {
+    public void testGetValue() throws Exception {
         when(configSource.repository.getConfigValue(anyString())).thenReturn("123");
         assertEquals("123", configSource.getValue("test"));
     }
-    
+
     @Test
-    public void testGetValue_cache() {
+    public void testGetValue_cache() throws Exception {
         when(configSource.repository.getConfigValue(anyString())).thenReturn("123");
         configSource.getValue("test");
         configSource.getValue("test");
         verify(configSource.repository, times(1)).getConfigValue(anyString());
+    }
+
+    @Test
+    public void testGetValue_exception() throws Exception {
+        when(configSource.repository.getConfigValue(anyString())).thenThrow(SQLException.class);
+        assertNull(configSource.getValue("test"));
+        verify(configSource, times(1)).clearRepository();
+    }
+
+    @Test
+    public void testGetValue_exception_cache() throws Exception {
+
+        // negative value, otherwise two serial "getValue" will have the same timestamp
+        // and the entry is not yet expired.
+        configSource.cache = new ExpiringMap<String, String>(-5);
+
+        when(configSource.repository.getConfigValue(anyString())).thenReturn("123");
+        assertEquals("123", configSource.getValue("test"));
+        when(configSource.repository.getConfigValue(anyString())).thenThrow(SQLException.class);
+        assertEquals("123", configSource.getValue("test")); // load from cache, also when the entry is already expired.
+        verify(configSource, times(1)).clearRepository();
+
     }
 
 }

--- a/configsource-db/src/test/java/org/microprofileext/config/source/db/RepositoryTest.java
+++ b/configsource-db/src/test/java/org/microprofileext/config/source/db/RepositoryTest.java
@@ -1,25 +1,23 @@
 package org.microprofileext.config.source.db;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Optional;
 
-import org.eclipse.microprofile.config.Config;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class RepositoryTest {
 
-
     Repository repository;
-    
+
     @BeforeEach
     public void init() {
         Config config = mock(Config.class);
@@ -31,7 +29,7 @@ class RepositoryTest {
     void testGetConfigValue_exception() throws SQLException {
         repository.selectOne = mock(PreparedStatement.class);
         when(repository.selectOne.executeQuery()).thenThrow(SQLException.class);
-        assertNull(repository.getConfigValue("test"));
+        assertThrows(SQLException.class, () -> repository.getConfigValue("test"));
     }
 
     @Test
@@ -45,7 +43,7 @@ class RepositoryTest {
 
     @Test
     void testGetConfigValue_no_stmt() throws SQLException {
-        assertNull(repository.getConfigValue("test"));
+        assertThrows(SQLException.class, () -> repository.getConfigValue("test"));
     }
 
     @Test
@@ -67,7 +65,7 @@ class RepositoryTest {
     void testGetAllConfigValues_exception() throws SQLException {
         repository.selectAll = mock(PreparedStatement.class);
         when(repository.selectAll.executeQuery()).thenThrow(SQLException.class);
-        assertEquals(0, repository.getAllConfigValues().size());
+        assertThrows(SQLException.class, () -> repository.getAllConfigValues().size());
     }
 
     @Test


### PR DESCRIPTION
I made quite a few changes to the consul and datasource config source in my own repo to make them more resilient over the last year. With this PR I want to bring the projects in sync:
- added ExpiringMap to configsource-base
- moved consul stuff in ConsulClientWrapper
- some improvements when connection to DB or consul is lost at runtime
- re-added getOrdinal() to respect specification (overwrite ordinal with a config)