### PR TITLE
Fix beans.xml files for CDI Lite

### DIFF
--- a/config-events/src/main/resources/META-INF/beans.xml
+++ b/config-events/src/main/resources/META-INF/beans.xml
@@ -2,5 +2,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/config-example/src/main/webapp/WEB-INF/beans.xml
+++ b/config-example/src/main/webapp/WEB-INF/beans.xml
@@ -2,5 +2,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/configconverter-json/src/main/resources/META-INF/beans.xml
+++ b/configconverter-json/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       bean-discovery-mode="all">
-</beans>

--- a/configconverter-list/src/main/resources/META-INF/beans.xml
+++ b/configconverter-list/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       bean-discovery-mode="all">
-</beans>

--- a/configsource-json/src/test/resources/META-INF/beans.xml
+++ b/configsource-json/src/test/resources/META-INF/beans.xml
@@ -2,5 +2,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/configsource-memory/src/main/resources/META-INF/beans.xml
+++ b/configsource-memory/src/main/resources/META-INF/beans.xml
@@ -2,5 +2,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/configsource-properties/src/test/resources/META-INF/beans.xml
+++ b/configsource-properties/src/test/resources/META-INF/beans.xml
@@ -2,5 +2,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/configsource-providers/src/main/resources/META-INF/beans.xml
+++ b/configsource-providers/src/main/resources/META-INF/beans.xml
@@ -2,5 +2,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/configsource-xml/src/main/resources/META-INF/beans.xml
+++ b/configsource-xml/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
-</beans>

--- a/configsource-xml/src/test/resources/META-INF/beans.xml
+++ b/configsource-xml/src/test/resources/META-INF/beans.xml
@@ -2,5 +2,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>

--- a/configsource-yaml/src/main/resources/META-INF/beans.xml
+++ b/configsource-yaml/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
-</beans>

--- a/configsource-yaml/src/test/resources/META-INF/beans.xml
+++ b/configsource-yaml/src/test/resources/META-INF/beans.xml
@@ -2,5 +2,5 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all">
+       bean-discovery-mode="annotated">
 </beans>


### PR DESCRIPTION
Quarkus complains that bean-discovery-mode="all" is not supported. This is because CDI Lite (on which Quarkus is based) only supports "annotated".

With this change, only the modules where CDI beans are actually defined keep their beans.xml file and the discovery mode is changed to "annotated". Some beans.xml files have been moved to test resources since they are needed by Arquillian.